### PR TITLE
Add failing test case for a word longer than line limit

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -19,6 +19,7 @@ for (let i = 0; i < 25; i++) {
       .replace(/\s{2}\r/g, ' ')
   )
 }
+texts.push('a bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbc'); // 51-character word
 
 describe('params', () => {
   describe('indent', () => {


### PR DESCRIPTION
An input string with a word longer than the line length limit, after at least one space, causes an exception to be thrown.

```
> require('hanging-indent')('a bbbbbbbbbbbbbbbbbbbbbbbbbbbbc', 2, 30);
RangeError: Maximum call stack size exceeded
    at Array.reverse (native)
    at hangingIndent (/tmp/test/node_modules/hanging-indent/index.js:21:57)
    at hangingIndent (/tmp/test/node_modules/hanging-indent/index.js:27:12)
    at hangingIndent (/tmp/test/node_modules/hanging-indent/index.js:27:12)
    at hangingIndent (/tmp/test/node_modules/hanging-indent/index.js:27:12)
    at hangingIndent (/tmp/test/node_modules/hanging-indent/index.js:27:12)
    at hangingIndent (/tmp/test/node_modules/hanging-indent/index.js:27:12)
    at hangingIndent (/tmp/test/node_modules/hanging-indent/index.js:27:12)
    at hangingIndent (/tmp/test/node_modules/hanging-indent/index.js:27:12)
    at hangingIndent (/tmp/test/node_modules/hanging-indent/index.js:27:12)
>
```
