### PR TITLE
Add failing test case for newlines

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -19,6 +19,7 @@ for (let i = 0; i < 25; i++) {
       .replace(/\s{2}\r/g, ' ')
   )
 }
+texts.push('Some text\nwith newline characters\nin it.');
 
 describe('params', () => {
   describe('indent', () => {
@@ -76,5 +77,16 @@ describe('lines', () => {
       .map(lengths => {
         assert.isFalse(lengths.every(length => length === 80))
       })
+  })
+})
+
+describe('newlines', () => {
+  it('newlines should be treated properly', () => {
+    assert.equal(hangingIndent(`A${' a'.repeat(50)}\nB${' b'.repeat(50)}`),
+        'A a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a\n'
+      + '    a a a a a a a a a a a\n'
+      + '    B b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b\n'
+      + '    b b b b b b b b b b b'
+    )
   })
 })


### PR DESCRIPTION
There are two modes of failure here. The first added test string shows that indentation is not properly added after a newline. The second part, which is a new type of test, shows that the line following the
newline does not extend to the full length limit before it is broken again by this module. (It also shows the first issue, but not part of the existing test framework, so I thought maybe both are valuable.) To
illustrate:

Expected (there's a newline just before the capital B):

    A a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
        a a a a a a a a a a a
        B b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
        b b b b b b b b b b b

Actual:

    A a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
        a a a a a a a a a a a
    B b b b b b b b b b b b b b b b b b b b b b b b b b b
        b b b b b b b b b b b b b b b b b b b b b b b b